### PR TITLE
Add version 2 and SampleActivity update with v2

### DIFF
--- a/ComposeUILib/src/main/java/com/stutx/composeuilib/v1/data/Action.kt
+++ b/ComposeUILib/src/main/java/com/stutx/composeuilib/v1/data/Action.kt
@@ -2,7 +2,7 @@
  * Copyright 2025 Ikuto-Akayama, All rights reserved.
  */
 
-package com.stutx.composeuilib.data
+package com.stutx.composeuilib.v1.data
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes

--- a/ComposeUILib/src/main/java/com/stutx/composeuilib/v1/data/TwoColumnWizardData.kt
+++ b/ComposeUILib/src/main/java/com/stutx/composeuilib/v1/data/TwoColumnWizardData.kt
@@ -2,7 +2,7 @@
  * Copyright 2025 Ikuto-Akayama, All rights reserved.
  */
 
-package com.stutx.composeuilib.data
+package com.stutx.composeuilib.v1.data
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes

--- a/ComposeUILib/src/main/java/com/stutx/composeuilib/v1/view/ActionButton.kt
+++ b/ComposeUILib/src/main/java/com/stutx/composeuilib/v1/view/ActionButton.kt
@@ -2,7 +2,7 @@
  * Copyright 2025 Ikuto-Akayama, All rights reserved.
  */
 
-package com.stutx.composeuilib.view
+package com.stutx.composeuilib.v1.view
 
 import android.content.res.Configuration
 import android.util.Log
@@ -27,8 +27,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stutx.composeuilib.R
-import com.stutx.composeuilib.data.Action
-import com.stutx.composeuilib.viewmodel.ActionCallback
+import com.stutx.composeuilib.v1.data.Action
+import com.stutx.composeuilib.v1.viewmodel.ActionCallback
 
 @Composable
 fun ActionButtons(

--- a/ComposeUILib/src/main/java/com/stutx/composeuilib/v1/view/ContentBlock.kt
+++ b/ComposeUILib/src/main/java/com/stutx/composeuilib/v1/view/ContentBlock.kt
@@ -2,7 +2,7 @@
  * Copyright 2025 Ikuto-Akayama, All rights reserved.
  */
 
-package com.stutx.composeuilib.view
+package com.stutx.composeuilib.v1.view
 
 import android.content.res.Configuration
 import androidx.annotation.DrawableRes

--- a/ComposeUILib/src/main/java/com/stutx/composeuilib/v1/view/TwoColumnWizard.kt
+++ b/ComposeUILib/src/main/java/com/stutx/composeuilib/v1/view/TwoColumnWizard.kt
@@ -2,7 +2,7 @@
  * Copyright 2025 Ikuto-Akayama, All rights reserved.
  */
 
-package com.stutx.composeuilib.view
+package com.stutx.composeuilib.v1.view
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
@@ -20,10 +20,10 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stutx.composeuilib.R
-import com.stutx.composeuilib.data.Action
-import com.stutx.composeuilib.data.TwoColumnWizardData
-import com.stutx.composeuilib.data.TwoColumnWizardExtra
-import com.stutx.composeuilib.viewmodel.ActionCallback
+import com.stutx.composeuilib.v1.data.Action
+import com.stutx.composeuilib.v1.data.TwoColumnWizardData
+import com.stutx.composeuilib.v1.data.TwoColumnWizardExtra
+import com.stutx.composeuilib.v1.viewmodel.ActionCallback
 
 @Composable
 fun TwoColumnWizard(

--- a/ComposeUILib/src/main/java/com/stutx/composeuilib/v1/viewmodel/ActionCallback.kt
+++ b/ComposeUILib/src/main/java/com/stutx/composeuilib/v1/viewmodel/ActionCallback.kt
@@ -2,7 +2,7 @@
  * Copyright 2025 Ikuto-Akayama, All rights reserved.
  */
 
-package com.stutx.composeuilib.viewmodel
+package com.stutx.composeuilib.v1.viewmodel
 
 import androidx.annotation.StringRes
 

--- a/ComposeUILib/src/main/java/com/stutx/composeuilib/v2/data/Action.kt
+++ b/ComposeUILib/src/main/java/com/stutx/composeuilib/v2/data/Action.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Ikuto-Akayama, All rights reserved.
+ */
+
+package com.stutx.composeuilib.v2.data
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+
+sealed class Action(open val id: Int) {
+    @Composable
+    abstract fun getTitle(): String?
+    @Composable
+    abstract fun getSubtitle(): String?
+    @Composable
+    abstract fun getIcon(): Painter?
+}
+
+data class ActionRes(
+    override val id: Int,
+    @StringRes val title: Int? = null,
+    @StringRes val subtitle: Int? = null,
+    @DrawableRes val icon: Int? = null,
+) : Action(id) {
+
+    @Composable
+    override fun getTitle(): String? {
+        return title?.let {
+            stringResource(it)
+        }
+    }
+
+    @Composable
+    override fun getSubtitle(): String? {
+        return subtitle?.let {
+            stringResource(it)
+        }
+    }
+
+    @Composable
+    override fun getIcon(): Painter? {
+        return icon?.let {
+            painterResource(it)
+        }
+    }
+}
+
+data class ActionRaw(
+    override val id: Int,
+    val title: String? = null,
+    val subtitle: String? = null,
+    val icon: Int? = null
+) : Action(id) {
+    @Composable
+    override fun getTitle(): String? = title
+
+    @Composable
+    override fun getSubtitle(): String? = subtitle
+
+    @Composable
+    override fun getIcon(): Painter? {
+        return icon?.let {
+            painterResource(it)
+        }
+    }
+}

--- a/ComposeUILib/src/main/java/com/stutx/composeuilib/v2/data/TextContents.kt
+++ b/ComposeUILib/src/main/java/com/stutx/composeuilib/v2/data/TextContents.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Ikuto-Akayama, All rights reserved.
+ */
+
+package com.stutx.composeuilib.v2.data
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+
+sealed class TextContents {
+    @Composable
+    abstract fun getTitle(): String?
+    @Composable
+    abstract fun getSubtitle(): String?
+    @Composable
+    abstract fun getDescription(): String?
+}
+
+data class TextContentsRes(
+    @StringRes val title: Int? = null,
+    @StringRes val subtitle: Int? = null,
+    @StringRes val description: Int? = null,
+) : TextContents() {
+    @Composable
+    override fun getTitle(): String? {
+        return title?.let {
+            stringResource(it)
+        }
+    }
+
+    @Composable
+    override fun getSubtitle(): String? {
+        return subtitle?.let {
+            stringResource(it)
+        }
+    }
+
+    @Composable
+    override fun getDescription(): String? {
+        return description?.let {
+            stringResource(it)
+        }
+    }
+
+}
+
+data class TextContentsRaw(
+    val title: String? = null,
+    val subtitle: String? = null,
+    val description: String? = null,
+) : TextContents() {
+    @Composable
+    override fun getTitle(): String? = title
+
+    @Composable
+    override fun getSubtitle(): String? = subtitle
+
+    @Composable
+    override fun getDescription(): String? = description
+}

--- a/ComposeUILib/src/main/java/com/stutx/composeuilib/v2/view/BottomDialog.kt
+++ b/ComposeUILib/src/main/java/com/stutx/composeuilib/v2/view/BottomDialog.kt
@@ -1,0 +1,122 @@
+
+/*
+ * Copyright 2025 Ikuto-Akayama, All rights reserved.
+ */
+
+package com.stutx.composeuilib.v2.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.stutx.composeuilib.R
+import com.stutx.composeuilib.v2.data.Action
+import com.stutx.composeuilib.v2.data.ActionRaw
+import com.stutx.composeuilib.v2.data.ActionRes
+import com.stutx.composeuilib.v2.data.TextContents
+import com.stutx.composeuilib.v2.data.TextContentsRaw
+import com.stutx.composeuilib.v2.view.component.ColumnButtons
+import com.stutx.composeuilib.v2.view.component.TextContentBlock
+import com.stutx.composeuilib.v2.viewmodel.ActionCallback
+
+@Composable
+fun BottomDialog(
+    contents: TextContents,
+    actions: List<Action>,
+    actionCallback: ActionCallback,
+    modifier: Modifier = Modifier
+) {
+    /** whole screen */
+    Surface(
+        modifier = modifier
+            .width(960.dp)
+            .height(540.dp)
+            .padding(vertical = 24.dp, horizontal = 24.dp)
+            .background(MaterialTheme.colorScheme.background)
+            .wrapContentSize(align = Alignment.BottomCenter)
+            .clip(RoundedCornerShape(14.dp))
+        ,
+        color = MaterialTheme.colorScheme.primary,
+    ) {
+        /** bottom half dialog */
+        Box(
+            modifier = modifier
+                .padding(vertical = 24.dp, horizontal = 34.dp)
+                .height(200.dp)
+                .fillMaxWidth()
+            ,
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight()
+            ) {
+                TextContentBlock(
+                    contents = contents,
+                    modifier = modifier
+                        .padding(end = 32.dp)
+                        .wrapContentHeight()
+                        .widthIn(max = 543.dp)
+                    ,
+                )
+                ColumnButtons(
+                    actions = actions,
+                    actionCallback = actionCallback,
+                    modifier = modifier
+                        .wrapContentHeight()
+                        .requiredWidth(268.dp)
+                    ,
+                )
+            }
+        }
+    }
+}
+
+@Preview(
+    locale = "en",
+    showBackground = true,
+    name = "BottomDialog preview",
+    device = Devices.TV_720p,
+)
+@Composable
+private fun BottomDialogPreview() {
+    val dummyCallback = object : ActionCallback {
+        override fun onSelected(action: Action) {
+            /* do something */
+        }
+    }
+    BottomDialog(
+        contents = TextContentsRaw(
+            title = "test title",
+            subtitle = "test subtitle",
+            description = "this is description!!!! toooooooooooooooooooooooo long text can set this. also line break is automatically",
+        ),
+        actions = listOf(
+            ActionRaw(id = 0, title = "raw action 1"),
+            ActionRes(id = 1, title = R.string.label_action_button_yes)
+        ),
+        actionCallback = dummyCallback,
+        modifier = Modifier
+    )
+}

--- a/ComposeUILib/src/main/java/com/stutx/composeuilib/v2/view/TwoColumnWizard.kt
+++ b/ComposeUILib/src/main/java/com/stutx/composeuilib/v2/view/TwoColumnWizard.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 Ikuto-Akayama, All rights reserved.
+ */
+
+package com.stutx.composeuilib.v2.view
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.stutx.composeuilib.R
+import com.stutx.composeuilib.v2.data.Action
+import com.stutx.composeuilib.v2.data.ActionRaw
+import com.stutx.composeuilib.v2.data.ActionRes
+import com.stutx.composeuilib.v2.data.TextContents
+import com.stutx.composeuilib.v2.data.TextContentsRaw
+import com.stutx.composeuilib.v2.view.component.ColumnButtons
+import com.stutx.composeuilib.v2.view.component.TextContentBlock
+import com.stutx.composeuilib.v2.viewmodel.ActionCallback
+
+@Composable
+fun TwoColumnWizard(
+    contents: TextContents,
+    actions: List<Action>,
+    actionCallback: ActionCallback,
+    modifier: Modifier = Modifier
+) {
+    /** whole screen */
+    Surface(
+        modifier = modifier
+            .width(960.dp)
+            .height(540.dp)
+            .padding(vertical = 28.dp, horizontal = 58.dp)
+            .wrapContentSize(align = Alignment.Center)
+        ,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = modifier
+                .padding(15.dp) // FIXME: This is workaround.
+                .width(700.dp)
+                .wrapContentHeight(Alignment.CenterVertically)
+        ) {
+            TextContentBlock(
+                contents = contents,
+                modifier = modifier
+                    .width(340.dp)
+                ,
+            )
+            ColumnButtons(
+                actions = actions,
+                actionCallback = actionCallback,
+                modifier = modifier
+                    .width(268.dp)
+                ,
+            )
+        }
+    }
+}
+
+@Preview(
+    locale = "en",
+    showBackground = true,
+    name = "TwoColumnWizard preview",
+    device = Devices.TV_720p,
+)
+@Composable
+private fun TwoColumnWizardPreview() {
+    val dummyCallback = object : ActionCallback {
+        override fun onSelected(action: Action) {
+            /* do something */
+        }
+    }
+    TwoColumnWizard(
+        contents = TextContentsRaw(
+            title = "test title",
+            subtitle = "test subtitle",
+            description = "this is description!!!! toooooooooooooooooooooooo long text can set this. also line break is automatically",
+        ),
+        actions = listOf(
+            ActionRaw(id = 0, title = "raw action 1"),
+            ActionRes(id = 1, title = R.string.label_action_button_yes)
+        ),
+        actionCallback = dummyCallback,
+        modifier = Modifier
+    )
+}

--- a/ComposeUILib/src/main/java/com/stutx/composeuilib/v2/view/component/ColumnButton.kt
+++ b/ComposeUILib/src/main/java/com/stutx/composeuilib/v2/view/component/ColumnButton.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2025 Ikuto-Akayama, All rights reserved.
+ */
+
+package com.stutx.composeuilib.v2.view.component
+
+import android.content.res.Configuration
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.stutx.composeuilib.R
+import com.stutx.composeuilib.v2.data.Action
+import com.stutx.composeuilib.v2.data.ActionRaw
+import com.stutx.composeuilib.v2.viewmodel.ActionCallback
+
+@Composable
+fun ColumnButtons(
+    actions: List<Action>,
+    actionCallback: ActionCallback,
+    modifier: Modifier,
+    initialFocusId: Int = Int.MIN_VALUE
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.Top),
+    ) {
+        val focusIndex =
+            actions.find { it.id == initialFocusId }?.id
+                ?: actions.firstOrNull()?.id
+        actions.forEachIndexed { index, action ->
+            val focusRequester = remember { FocusRequester() }
+            ActionButtonV2(
+                action = action,
+                actionCallback = actionCallback,
+                focusRequester = focusRequester
+            )
+            if (focusIndex == action.id) {
+                LaunchedEffect(Unit) { focusRequester.requestFocus() }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun ActionButtonV2(
+    action: Action,
+    actionCallback: ActionCallback,
+    modifier: Modifier = Modifier,
+    focusRequester: FocusRequester
+) {
+    var focused by remember { mutableStateOf(false) }
+    FilledTonalButton(
+        onClick = {
+            focusRequester.requestFocus()
+            actionCallback.onSelected(action)
+            focused = true
+        },
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier
+            .focusRequester(focusRequester)
+            .onFocusChanged { state ->
+                focused = state.isFocused
+            }
+            .fillMaxWidth()
+            .scale(if (focused) 1.075f else 1f)
+            .focusable()
+        ,
+        contentPadding = PaddingValues(
+            horizontal = 16.dp,
+            vertical = 12.dp
+        ),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.weight(1f)
+        ) {
+            action.getIcon()?.let {
+                Icon(
+                    painter = it,
+                    contentDescription = null,
+                    modifier = Modifier.align(alignment = Alignment.CenterVertically)
+                )
+            }
+            if (action.getTitle() != null || action.getSubtitle() != null) {
+                ActionTextsV2(
+                    action = action,
+                    modifier = modifier
+
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActionTextsV2(
+    action: Action,
+    modifier: Modifier = Modifier
+) {
+    Column {
+        action.getTitle()?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = modifier
+                    .align(Alignment.Start),
+            )
+        }
+        action.getSubtitle()?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = modifier
+            )
+        }
+    }
+}
+
+@Preview(
+    locale = "en",
+    showBackground = true,
+    name = "TextContentBlock preview(raw)",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+private fun ColumnButtonPreview() {
+    val dummyCallback = object : ActionCallback {
+        override fun onSelected(action: Action) {
+            /* nop */
+        }
+    }
+    ColumnButtons(
+        actions = listOf(
+            ActionRaw(id = 0, title = "action1 button1"),
+            ActionRaw(id = 1, title = "action1 button2", subtitle = "subtitle exist"),
+            ActionRaw(
+                id = 2,
+                title = "action1 button3",
+                icon = R.drawable.baseline_arrow_right_24
+            ),
+            ActionRaw(
+                id = 3,
+                title = "action1 button4",
+                subtitle = "subtitle exist",
+                icon = R.drawable.baseline_arrow_right_24
+            ),
+        ),
+        actionCallback = dummyCallback,
+        modifier = Modifier,
+        initialFocusId = -1
+    )
+}

--- a/ComposeUILib/src/main/java/com/stutx/composeuilib/v2/view/component/TextContentBlock.kt
+++ b/ComposeUILib/src/main/java/com/stutx/composeuilib/v2/view/component/TextContentBlock.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 Ikuto-Akayama, All rights reserved.
+ */
+
+package com.stutx.composeuilib.v2.view.component
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.LineBreak
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.stutx.composeuilib.R
+import com.stutx.composeuilib.v2.data.TextContents
+import com.stutx.composeuilib.v2.data.TextContentsRaw
+import com.stutx.composeuilib.v2.data.TextContentsRes
+
+@Composable
+fun TextContentBlock(
+    contents: TextContents,
+    modifier: Modifier
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Top),
+    ) {
+        /** title and subtitle */
+        if (contents.getTitle() != null || contents.getSubtitle() != null) {
+            Heading(contents, modifier)
+        }
+        /** descriptions */
+        contents.getDescription()?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    lineBreak = LineBreak.Paragraph
+                ),
+                modifier = modifier
+            )
+        }
+    }
+}
+
+@Composable
+private fun Heading(
+    contents: TextContents,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp, Alignment.Top),
+        horizontalAlignment = Alignment.Start
+    ) {
+        contents.getTitle()?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = modifier,
+            )
+        }
+        contents.getSubtitle()?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = modifier
+            )
+        }
+    }
+}
+
+@Preview(
+    locale = "en",
+    showBackground = true,
+    name = "TextContentBlock preview(raw)",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+private fun TextContentBlockPreview1() {
+    TextContentBlock(
+        contents = TextContentsRaw(
+            title = "test title",
+            subtitle = "test subtitle",
+            description = "this is description!!!!",
+        ),
+        modifier = Modifier
+    )
+}
+
+@Preview(
+    locale = "en",
+    showBackground = true,
+    name = "TextContentBlock preview(res)",
+)
+@Composable
+private fun TextContentBlockPreview2() {
+    TextContentBlock(
+        contents = TextContentsRes(
+            title = R.string.label_dialog_title,
+            subtitle = R.string.label_dialog_subtitle,
+            description = R.string.label_dialog_description
+        ),
+        modifier = Modifier
+    )
+}

--- a/ComposeUILib/src/main/java/com/stutx/composeuilib/v2/viewmodel/ActionCallback.kt
+++ b/ComposeUILib/src/main/java/com/stutx/composeuilib/v2/viewmodel/ActionCallback.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 Ikuto-Akayama, All rights reserved.
+ */
+
+package com.stutx.composeuilib.v2.viewmodel
+
+import com.stutx.composeuilib.v2.data.Action
+
+interface ActionCallback {
+    fun onSelected(action: Action)
+}

--- a/app/src/main/java/com/stutx/composetestapp/view/SampleActivity.kt
+++ b/app/src/main/java/com/stutx/composetestapp/view/SampleActivity.kt
@@ -12,31 +12,45 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.ui.Modifier
 import com.stutx.composetestapp.R
 import com.stutx.composetestapp.view.ui.theme.ComposeTestAppTheme
-import com.stutx.composeuilib.data.Action
-import com.stutx.composeuilib.data.TwoColumnWizardData
-import com.stutx.composeuilib.view.TwoColumnWizard
-import com.stutx.composeuilib.viewmodel.ActionCallback
+import com.stutx.composeuilib.v2.data.Action
+import com.stutx.composeuilib.v2.data.ActionRaw
+import com.stutx.composeuilib.v2.data.ActionRes
+import com.stutx.composeuilib.v2.data.TextContentsRaw
+import com.stutx.composeuilib.v2.view.TwoColumnWizard
+import com.stutx.composeuilib.v2.viewmodel.ActionCallback
 
 class SampleActivity : ComponentActivity() {
 
     private val callback = object : ActionCallback {
-        override fun onSelected(id: Int) {
+        override fun onSelected(action: Action) {
             val context = this@SampleActivity.applicationContext
             Toast.makeText(
                 context,
-                "${context.getText(id)} is selected",
+                "${action.id} is selected.",
                 Toast.LENGTH_SHORT
             ).show()
         }
     }
 
     private val actionList = listOf(
-        Action(R.string.label_action_button_1),
-        Action(
+        ActionRes(
+            id = 0,
+            title = R.string.label_action_button_1),
+        ActionRes(
+            id = 1,
             title = R.string.label_action_button_2,
             icon = com.stutx.composeuilib.R.drawable.baseline_arrow_right_24
         ),
-        Action(R.string.label_action_button_3)
+        ActionRes(
+            id = 2,
+            title = R.string.label_action_button_3
+        ),
+        ActionRaw(
+            id = 3,
+            title = "Action Button 4",
+            subtitle = "This is raw version",
+            icon = com.stutx.composeuilib.R.drawable.baseline_arrow_right_24
+        )
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -45,15 +59,14 @@ class SampleActivity : ComponentActivity() {
         setContent {
             ComposeTestAppTheme {
                 TwoColumnWizard(
-                    modifier = Modifier,
-                    data = TwoColumnWizardData(
-                        title = R.string.label_title_activity_sample,
-                        subtitle = R.string.label_subtitle_activity_sample,
-                        description = R.string.label_description_activity_sample,
-                        extra = null
+                    contents = TextContentsRaw(
+                        title = "test title",
+                        subtitle = "test subtitle",
+                        description = "this is description!!!! toooooooooooooooooooooooo long text can set this. also line break is automatically",
                     ),
-                    callback = callback,
-                    actions = actionList
+                    actions = actionList,
+                    actionCallback = callback,
+                    modifier = Modifier
                 )
             }
         }


### PR DESCRIPTION
## v2 new features:
* Action
  * idを付与した
  * /resから文言を引っ張って読むやつとrawのStringを食わせるやつの2パターン作った
* TextContents
  * simpleに文字列だけを突っ込むようなdataクラスを導入した
  * /resから文言を引っ張るやつとrawのStringを食わせる2パターン作った
* ColumnButton
  * パーツごとに使えるようにすることを意識してレイアウトを後段で制御できるように設計をブラッシュアップした
  * フォーカスされたButtonのレイアウトがclipされる問題を修正（一時しのぎ感…）
  * 初期フォーカス位置の指定に対応した
* BottomDialog
  * TextContentsとColumnButtonを使った別レイアウトを導入
![image](https://github.com/user-attachments/assets/056b5c99-ef36-4513-bd91-864cb26b7d9c)